### PR TITLE
V model compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Vue.component('markdown-editor', MarkdownEditor)
 #### Props
 | name | type | required | default | description |
 | :--- | ---- | ---------| ------- | ----------- |
-| name | `String` | `true` | `null` | The name of the textarea |
+| name | `String` | `false` | `null` | The name of the textarea |
 | content | `String` | `false` | `''` | Default content |
 | autosave | `Boolean` | `false` | `false` | If it should autosave |
 | autosaveSwitchVisible | `Boolean` | `false` | `true` | If the autosave switch should be shown in the bottom part of the editor |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Vue.component('markdown-editor', MarkdownEditor)
 | name | `String` | `true` | `null` | The name of the textarea |
 | content | `String` | `false` | `''` | Default content |
 | autosave | `Boolean` | `false` | `false` | If it should autosave |
+| autosaveSwitchVisible | `Boolean` | `false` | `true` | If the autosave switch should be shown in the bottom part of the editor |
 | autosaveUrl | `String` | `false` | `null` | The url endpoint to autosave |
 | autosaveMethod | `String` | `false` | `patch` | The rest verb for submitting the request |
 | options | `Object` | `false` | `{ html: true, linkify: true, breaks: true }` | Options to pass to `markdown-it`. See more at [markdown-it documentation](https://github.com/markdown-it/markdown-it)

--- a/docs/App.vue
+++ b/docs/App.vue
@@ -10,6 +10,12 @@
       <div class="content" v-html="rendered">
       </div>
     </section>
+      <p class="control">
+        <button class="button is-primary"
+                @click="reset">
+          Reset
+        </button>
+      </p>
   </div>
 </template>
 
@@ -29,6 +35,11 @@
       rendered: function () {
         var mdRenderer = new MarkdownIt()
         return mdRenderer.render(this.contentRaw)
+      }
+    },
+    methods: {
+      reset () {
+        this.contentRaw = ''
       }
     }
   }

--- a/docs/App.vue
+++ b/docs/App.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <markdown-editor :autosave-switch-visible="false"/>
+    <div class="content">
+      Blanlaa
+    </div>
+  </div>
+</template>
+
+<script>
+  import Vue from 'vue'
+  import { MarkdownEditor } from '../src'
+  Vue.component('markdown-editor', MarkdownEditor)
+  export default {
+    name: "App"
+  }
+</script>
+
+<style scoped>
+.content {
+  margin-top: 2em;
+}
+</style>

--- a/docs/App.vue
+++ b/docs/App.vue
@@ -1,23 +1,41 @@
 <template>
   <div>
-    <markdown-editor :autosave-switch-visible="false"/>
-    <div class="content">
-      Blanlaa
-    </div>
+    <markdown-editor v-model="contentRaw" name="contentBox"/>
+    <section class="section results">
+      <div class="content">
+        {{ contentRaw }}
+      </div>
+    </section>
+    <section class="section">
+      <div class="content" v-html="rendered">
+      </div>
+    </section>
   </div>
 </template>
 
 <script>
   import Vue from 'vue'
   import { MarkdownEditor } from '../src'
+  import MarkdownIt from 'markdown-it'
   Vue.component('markdown-editor', MarkdownEditor)
   export default {
-    name: "App"
+    name: "App",
+    data: function () {
+      return {
+        contentRaw: '# Something',
+      }
+    },
+    computed: {
+      rendered: function () {
+        var mdRenderer = new MarkdownIt()
+        return mdRenderer.render(this.contentRaw)
+      }
+    }
   }
 </script>
 
 <style scoped>
-.content {
+.results {
   margin-top: 2em;
 }
 </style>

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,10 +1,11 @@
 import Vue from 'vue'
-import { MarkdownEditor } from '../src'
+import App from './App'
 
 new Vue({
     el: '#app',
 
     components: {
-        MarkdownEditor,
-    }
+        App,
+    },
+    template: '<App/>'
 })

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,10 +5,9 @@
 </head>
 <body>
 
-<div id="app">
-    <div class="columns" style="margin-top: 50px;">
-        <div class="column is-8 is-offset-2">
-            <markdown-editor name="content" :autosave="true"></markdown-editor>
+<div class="columns" style="margin-top: 50px;">
+    <div class="column is-8 is-offset-2">
+        <div id="app">
         </div>
     </div>
 </div>

--- a/src/components/AutosizeTextarea.vue
+++ b/src/components/AutosizeTextarea.vue
@@ -1,15 +1,26 @@
 <template>
-    <textarea @input="onChange" :name="name" :class="classes" v-html="content"></textarea>
+    <textarea v-model="body" v-on:input="$emit('input', $event.target.value)">
+    </textarea>
 </template>
 
 <script>
     import autosize from 'autosize'
 
     export default {
+      name: 'AutosizeTextarea',
+      props: ['value'],
         mounted() {
             autosize(this.$el)
         },
-
-        props: ['classes', 'onChange', 'content', 'name'],
+      data: function () {
+        return {
+          body: this.value,
+        }
+      },
+      watch: {
+        value: function(newVal) {
+          this.body = newVal
+        }
+      }
     }
 </script>

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -10,7 +10,11 @@
         <div>
             <div v-show="activeTab == 'content'" id="markdown-editor">
                 <keep-alive>
-                    <autosize-textarea :name="name" :onChange="handleChange" :content="body" classes="textarea"></autosize-textarea>
+                    <autosize-textarea :value="body"
+                                       v-on:input="$emit('input', $event)"
+                                       class="textarea">
+
+                    </autosize-textarea>
                 </keep-alive>
 
                 <transition name="fade">
@@ -69,7 +73,7 @@
 
         model: {
           prop: 'content',
-          event: 'change'
+          event: 'input'
         },
 
         computed: {
@@ -99,16 +103,6 @@
         },
 
         methods: {
-            handleChange(e) {
-                this.body = e.target.value
-
-                this.$emit('change', this.body)
-
-                if (this.autosaveIsActive) {
-                    this.save()
-                }
-            },
-
             save: _.debounce(function() {
                 if (! this.autosaveUrl) {
                     return
@@ -161,7 +155,7 @@
             },
 
             name: {
-                required: true,
+                required: false,
                 type: String,
             },
 
@@ -176,7 +170,16 @@
                 },
 
             },
-        }
+        },
+      watch: {
+          content: function(newContent) {
+            this.body = newContent
+
+            if (this.autosaveIsActive) {
+              this.save()
+            }
+          }
+      }
     }
 </script>
 

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -17,7 +17,7 @@
                     <p class="help is-pulled-left" style="padding-left: 10px;" v-show="showSaved">Last auto saved at {{ lastSavedAt }}</p>
                 </transition>
 
-                <div class="field is-pulled-right" style="min-width: 140px;">
+                <div class="field is-pulled-right" style="min-width: 140px;" v-show="autosaveShowSwitch">
                     <input id="markdown-autosave" type="checkbox" name="markdown-autosave" class="switch is-thin" :checked="autosave" v-model="autosaveIsActive">
                     <label for="markdown-autosave" style="font-size: 0.7rem; padding-top: 0.3rem;">Autosave {{ autosaveStatusText }}</label>
                 </div>
@@ -87,6 +87,7 @@
                 body: this.content,
                 markdownReferences: MarkdownReferences,
                 showSaved: false,
+                autosaveShowSwitch: this.autosaveSwitchVisible,
                 lastSavedAt: null,
                 autosaveIsActive: this.autosave
             }
@@ -140,6 +141,11 @@
             autosaveMethod: {
                 default: 'patch',
                 type: String,
+            },
+
+            autosaveSwitchVisible: {
+                default: true,
+                type: Boolean,
             },
 
             content: {

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -67,6 +67,11 @@
             Markdown,
         },
 
+        model: {
+          prop: 'content',
+          event: 'change'
+        },
+
         computed: {
             autosaveStatusText() {
                 return this.autosaveIsActive ? 'On' : 'Off'
@@ -96,6 +101,8 @@
         methods: {
             handleChange(e) {
                 this.body = e.target.value
+
+                this.$emit('change', this.body)
 
                 if (this.autosaveIsActive) {
                     this.save()


### PR DESCRIPTION
Added two bits of code so that MarkdownEditor can be used without custom save/autosave url:
* it implements vue's `v-model` so that the changes in the editor are available to the vue app directly
* the autosave switch display can be disabled through `autosave-switch-visible` prop, as this switch is not necessary if autosave is implemented in the parent vue application.

To demo the changes above, the example also needed to be reworked a bit...