### PR TITLE
Updated dependencies and devDependencies to make the project buildable (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,32 +28,34 @@
     "url": "https://github.com/tonning/vue-bulma-markdown-editor/issues"
   },
   "homepage": "https://github.com/tonning/vue-bulma-markdown-editor#readme",
-  "devDependencies": {
+  "dependencies": {
     "axios": "^0.16.2",
+    "vue": "^2.4.4"
+  },
+  "devDependencies": {
+    "autosize": "^4.0.0",
     "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.0",
-    "css-loader": "^0.28.7",
-    "node-sass": "^4.5.3",
-    "sass-loader": "^6.0.6",
-    "style-loader": "^0.18.2",
-    "vue": "^2.4.4",
-    "vue-loader": "^13.0.4",
-    "vue-template-compiler": "^2.4.4",
-    "webpack": "^3.6.0",
-    "webpack-merge": "^4.1.0"
-  },
-  "dependencies": {
-    "autosize": "^4.0.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-loader": "^7.1.2",
     "babel-runtime": "^6.26.0",
     "bulma": "^0.5.2",
     "bulma-switch": "^0.0.3",
+    "css-loader": "^0.28.7",
     "lodash": "^4.17.4",
     "markdown-it": "^8.4.0",
     "markdown-it-attrs": "^1.2.0",
-    "moment": "^2.18.1"
+    "moment": "^2.18.1",
+    "node-sass": "^4.5.3",
+    "sass-loader": "^6.0.6",
+    "style-loader": "^0.18.2",
+    "vue-loader": "^13.0.4",
+    "vue-template-compiler": "^2.4.4",
+    "webpack": "3.6.0",
+    "webpack-merge": "^4.1.0",
+    "webpack-dev-server": "2.9.1",
+    "webpack-cli": "2.1.4"
   }
 }


### PR DESCRIPTION
When npm-installed on a clean environment, the project wouldn't build as it wasn't forward compatible with some recent changes in the toolchain. Webpack and its parts needed to be version-freezed @3.6.0.

While at it, I also sorted out the devDependencies.
